### PR TITLE
💄 Fix word breaks in github section

### DIFF
--- a/api/utils/db.ts
+++ b/api/utils/db.ts
@@ -7,6 +7,8 @@ export async function initDbClient(): Promise<MongoClient> {
     useUnifiedTopology: true,
     ignoreUndefined: true
   });
+
+  // eslint-disable-next-line no-console
   console.log('✔️   Connected to Database');
   return dbClient;
 }

--- a/components/home/repo.tsx
+++ b/components/home/repo.tsx
@@ -39,7 +39,7 @@ export default function RepoDetails(): JSX.Element {
                 <Tilt className="Tilt" options={{ max: 25 }}>
                   <div className="bg-violet p-10 rounded-3xl shadow-violet-5xl">
                     <p className="text-5xl mb-6 font-bold">{repoData.name}</p>
-                    <p>{repoData.description}</p>
+                    <p className="break-words">{repoData.description}</p>
                     <div className="flex justify-evenly items-center mt-10 mb-5">
                       <div className="flex justify-center items-center">
                         <img src="/images/icons/warning.svg" alt="warning" className="h-6" />

--- a/styles/global.css
+++ b/styles/global.css
@@ -62,6 +62,11 @@ a {
   background: #b8c1ec;
 }
 
+.break-words {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 .gradient-text {
   background-color: #b8c1ec;
   background-image: linear-gradient(45deg, #eebbc3, #b8c1ec);


### PR DESCRIPTION
# Description

I've added the tailwind class break-words to the p tag mentioned in the issue. Tested on mozilla and chrome. In a pre-commit hook, eslint was giving an error for a console.log which was coming from `./api/utils/db.ts`.
I've added `// eslint-disable-next-line no-console` for that line.

Fixes #84 

## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [*] Tested on chrome and firefox.

# Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [*] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [*] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
