### PR TITLE
💄 Active state indicator for Explore

### DIFF
--- a/shared/components/navbar.tsx
+++ b/shared/components/navbar.tsx
@@ -18,8 +18,8 @@ const NavItem = ({ href, title }: Props): JSX.Element => {
       <a>
         <li
           className={`
-          px-5 py-2 pt-1 md:pt-4
-          ${router.pathname === href ? 'border-b-2 md:border-none' : ''} 
+          px-5 py-2 pt-1 md:pt-4 md:px-4 md:text-center
+          ${router.asPath === href ? 'border-b-2 md:border-none' : ''} 
           `}>
           <p className="transition duration-500 ease-in-out transform md:hover:-translate-y-2 text-white font-bold md:hover:text-violet">
             {title}
@@ -28,8 +28,8 @@ const NavItem = ({ href, title }: Props): JSX.Element => {
             src="/images/vectors/nav_active.svg"
             alt="nav-active"
             className={`
-            hidden 
-            ${router.asPath === href && 'md:block md:w-100'}
+            hidden md:block md:opacity-0
+            ${router.asPath === href && 'md:opacity-100 md:w-100'}
             `}
           />
         </li>

--- a/shared/components/navbar.tsx
+++ b/shared/components/navbar.tsx
@@ -29,7 +29,7 @@ const NavItem = ({ href, title }: Props): JSX.Element => {
             alt="nav-active"
             className={`
             hidden 
-            ${router.pathname === href && 'md:block md:w-100'}
+            ${router.asPath === href && 'md:block md:w-100'}
             `}
           />
         </li>


### PR DESCRIPTION
# Description
This PR fixes the explore navitem not showing an active state indicator when clicked. Instead of using pathname, we can use `router.asPath` to fix it. This is however a workaround and would be unusable is there are dynamic paths. But since navbar is usually non-dynamic paths it can be used here.
A better implementation would be to use [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to check when the particular DOM node is in view.

Fixes #74 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] End to end tested on browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
