### PR TITLE
fix headers for individual pages (#76)

### DIFF
--- a/pages/connect.tsx
+++ b/pages/connect.tsx
@@ -3,6 +3,7 @@ import { PersonalDetailsContext } from '@utils/contexts';
 import { PersonalDetails } from '@utils/types';
 import { Footer, Loader, Navbar } from '@shared-components';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 
 type Props = {
   personalDetails: PersonalDetails;
@@ -16,6 +17,10 @@ const ConnectPage = dynamic(() => import('../components/connect/index'), {
 const Contact = ({ personalDetails }: Props): JSX.Element => {
   return (
     <>
+      <Head>
+        <title>Harsh Goel | Contact</title>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      </Head>
       <PersonalDetailsContext.Provider value={personalDetails}>
         <Navbar />
         <ConnectPage />

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -3,6 +3,7 @@ import { getPersonalDetails, getProjectDetails } from '@utils/apiService';
 import { PersonalDetailsContext, ProjectDetailsContext } from '@utils/contexts';
 import { PersonalDetails, Project } from '@utils/types';
 import { Footer, Loader, Navbar, SocialBar } from '@shared-components';
+import Head from 'next/head';
 
 const ProjectsPage = dynamic(() => import('../components/projects/index'), {
   ssr: false,
@@ -16,6 +17,10 @@ type Props = {
 const Projects = ({ personalDetails, projectDetails }: Props): JSX.Element => {
   return (
     <>
+      <Head>
+        <title>Harsh Goel | Projects</title>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      </Head>
       <PersonalDetailsContext.Provider value={personalDetails}>
         <ProjectDetailsContext.Provider value={projectDetails}>
           <Navbar />

--- a/pages/work.tsx
+++ b/pages/work.tsx
@@ -3,6 +3,7 @@ import { Footer, Loader, Navbar } from '@shared-components';
 import { getPersonalDetails, getCompanyDetails } from '@utils/apiService';
 import { Company, PersonalDetails } from '@utils/types';
 import { CompanyDetailsContext, PersonalDetailsContext } from '@utils/contexts';
+import Head from 'next/head';
 
 const WorkPage = dynamic(() => import('../components/work/index'), {
   ssr: false,
@@ -17,6 +18,10 @@ type Props = {
 const Work = ({ personalDetails, companyDetails }: Props): JSX.Element => {
   return (
     <>
+      <Head>
+        <title>Harsh Goel | Work</title>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      </Head>
       <PersonalDetailsContext.Provider value={personalDetails}>
         <CompanyDetailsContext.Provider value={companyDetails}>
           <Navbar />


### PR DESCRIPTION
# Description

Added headers for Projects, Work, & Contact page using `<Head></Head>` from `next/head`

Fixes # (76)

## Test
Hover over to the tab when on Work/Projects/Contact section

